### PR TITLE
Remove dependency Illuminate/Support because it's no real dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "ext-gd": "*",
-        "illuminate/support": "4.x"
+        "ext-gd": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Furthermore it fails on Laravel 5.
